### PR TITLE
Uninstall solution individually

### DIFF
--- a/SPSD.Script/Scripts/SPSD_Deployment.ps1
+++ b/SPSD.Script/Scripts/SPSD_Deployment.ps1
@@ -1838,8 +1838,6 @@
                                 if ($solution.ContainsWebApplicationResource)
                                 {
 
-
-
                                      $caUrl = (Get-spwebapplication -includecentraladministration | where {$_.IsAdministrationWebApplication}).Url
                                      if(($solution.DeployedWebApplications | ? { $_.Url -eq $caUrl}) -ne $null){
                                         # Solution also deployed to central admin 
@@ -1849,7 +1847,9 @@
                                         WaitForJobToFinish $solutionName -Retract
                                         Log -Message "Retracting (all other web applications)..." -Type $SPSD.LogTypes.Normal -NoNewline
                                      }
-                                     Uninstall-SPSolution -Identity $solutionName -AllWebApplications -Confirm:$false
+                                     $solution.DeployedWebApplications |? { $_.Url -ne $caUrl } |% {
+                                         Uninstall-SPSolution -Identity "$solutionName" -WebApplication $_.Url -Confirm:$false
+                                     }
                                 }
                                 else
                                 {


### PR DESCRIPTION
Uninstall-SPSolution -AllWebApplication , may fail or timeout if farm solution is not deployed to all Web Application.  The fix, replaces -AllWebApplication by iterating through DeployedWebApplication and uninstall it individually. 
It has been tested in PROD scenario where SPSD failed/timeout initially.