### PR TITLE
Fixed the order of passing arguments from bat files when running the main script

### DIFF
--- a/SPSD.Script/Batches/Deploy.bat
+++ b/SPSD.Script/Batches/Deploy.bat
@@ -77,5 +77,5 @@ IF NOT "%ExecutionPolicy%"=="Bypass" IF NOT "%ExecutionPolicy%"=="Unrestricted" 
 	)
 GOTO LAUNCHSCRIPT
 :LAUNCHSCRIPT
-"%SYSTEMROOT%\system32\windowspowershell\v1.0\powershell.exe" -Command Start-Process "$PSHOME\powershell.exe" -Verb RunAs -ArgumentList '-Version %PSVersion%  "%~dp0\Scripts\SPSD_Main.ps1 -Command %command% -Type %type% -Verbosity %verbosity% %saveEnvXml% %envFile%"'
+"%SYSTEMROOT%\system32\windowspowershell\v1.0\powershell.exe" -Command Start-Process "$PSHOME\powershell.exe" -Verb RunAs -ArgumentList '-Version %PSVersion%  "%~dp0\Scripts\SPSD_Main.ps1 -Command %command% -Type %type% -Verbosity %verbosity% %envFile% %saveEnvXml%"'
 ENDLOCAL

--- a/SPSD.Script/Batches/Redeploy.bat
+++ b/SPSD.Script/Batches/Redeploy.bat
@@ -77,5 +77,5 @@ IF NOT "%ExecutionPolicy%"=="Bypass" IF NOT "%ExecutionPolicy%"=="Unrestricted" 
 	)
 GOTO LAUNCHSCRIPT
 :LAUNCHSCRIPT
-"%SYSTEMROOT%\system32\windowspowershell\v1.0\powershell.exe" -Command Start-Process "$PSHOME\powershell.exe" -Verb RunAs -ArgumentList '-Version %PSVersion%  "%~dp0\Scripts\SPSD_Main.ps1 -Command %command% -Type %type% -Verbosity %verbosity% %saveEnvXml% %envFile%"'
+"%SYSTEMROOT%\system32\windowspowershell\v1.0\powershell.exe" -Command Start-Process "$PSHOME\powershell.exe" -Verb RunAs -ArgumentList '-Version %PSVersion%  "%~dp0\Scripts\SPSD_Main.ps1 -Command %command% -Type %type% -Verbosity %verbosity% %envFile% %saveEnvXml%"'
 ENDLOCAL

--- a/SPSD.Script/Batches/Retract.bat
+++ b/SPSD.Script/Batches/Retract.bat
@@ -77,5 +77,5 @@ IF NOT "%ExecutionPolicy%"=="Bypass" IF NOT "%ExecutionPolicy%"=="Unrestricted" 
 	)
 GOTO LAUNCHSCRIPT
 :LAUNCHSCRIPT
-"%SYSTEMROOT%\system32\windowspowershell\v1.0\powershell.exe" -Command Start-Process "$PSHOME\powershell.exe" -Verb RunAs -ArgumentList '-Version %PSVersion%  "%~dp0\Scripts\SPSD_Main.ps1 -Command %command% -Type %type% -Verbosity %verbosity% %saveEnvXml% %envFile%"'
+"%SYSTEMROOT%\system32\windowspowershell\v1.0\powershell.exe" -Command Start-Process "$PSHOME\powershell.exe" -Verb RunAs -ArgumentList '-Version %PSVersion%  "%~dp0\Scripts\SPSD_Main.ps1 -Command %command% -Type %type% -Verbosity %verbosity% %envFile% %saveEnvXml%"'
 ENDLOCAL

--- a/SPSD.Script/Batches/RunOnlyExtensions.bat
+++ b/SPSD.Script/Batches/RunOnlyExtensions.bat
@@ -77,5 +77,5 @@ IF NOT "%ExecutionPolicy%"=="Bypass" IF NOT "%ExecutionPolicy%"=="Unrestricted" 
 	)
 GOTO LAUNCHSCRIPT
 :LAUNCHSCRIPT
-"%SYSTEMROOT%\system32\windowspowershell\v1.0\powershell.exe" -Command Start-Process "$PSHOME\powershell.exe" -Verb RunAs -ArgumentList '-Version %PSVersion%  "%~dp0\Scripts\SPSD_Main.ps1 -Command %command% -Type %type% -Verbosity %verbosity% %saveEnvXml% %envFile%"'
+"%SYSTEMROOT%\system32\windowspowershell\v1.0\powershell.exe" -Command Start-Process "$PSHOME\powershell.exe" -Verb RunAs -ArgumentList '-Version %PSVersion%  "%~dp0\Scripts\SPSD_Main.ps1 -Command %command% -Type %type% -Verbosity %verbosity% %envFile% %saveEnvXml%"'
 ENDLOCAL

--- a/SPSD.Script/Batches/Update.bat
+++ b/SPSD.Script/Batches/Update.bat
@@ -77,5 +77,5 @@ IF NOT "%ExecutionPolicy%"=="Bypass" IF NOT "%ExecutionPolicy%"=="Unrestricted" 
 	)
 GOTO LAUNCHSCRIPT
 :LAUNCHSCRIPT
-"%SYSTEMROOT%\system32\windowspowershell\v1.0\powershell.exe" -Command Start-Process "$PSHOME\powershell.exe" -Verb RunAs -ArgumentList '-Version %PSVersion%  "%~dp0\Scripts\SPSD_Main.ps1 -Command %command% -Type %type% -Verbosity %verbosity% %saveEnvXml% %envFile%"'
+"%SYSTEMROOT%\system32\windowspowershell\v1.0\powershell.exe" -Command Start-Process "$PSHOME\powershell.exe" -Verb RunAs -ArgumentList '-Version %PSVersion%  "%~dp0\Scripts\SPSD_Main.ps1 -Command %command% -Type %type% -Verbosity %verbosity% %envFile% %saveEnvXml%"'
 ENDLOCAL


### PR DESCRIPTION
Current versions of *.bat scripts is not correctly mapping arguments while calling `SPSD_Main.ps1`

Order of input params
```powershell
param 
(
    #optional parameter
    [ValidateNotNullOrEmpty()]
    [ValidateSet('Deploy', 'Redeploy', 'Retract', 'Update', 'Ask')]
    [string]$Command = "Deploy",

    [ValidateNotNullOrEmpty()]
    [ValidateSet('All', 'Solutions', 'Extensions')]
    [string]$Type = "All",          # Makes it possible to only deploy the solutions or the defined site structure

    [ValidateNotNullOrEmpty()]
    [ValidateSet('Error', 'Warning', 'Information', 'Verbose', 'VerboseExtended')]
    [string]$Verbosity = "verbose", # defines how detailed the log is created each level includes the ones above
    [string]$envFile,               # external environment configuration file
    [switch]$saveEnvXml = $true,    # filename of the used environment configuration (merged file of referenced files with replaced variables)
    [string]$solutionDirectory = "" # Optional: specify a custom folder location where the solutions files are stored
)
```